### PR TITLE
Bugfix: Default action on nginx unit image

### DIFF
--- a/files/unit/unit-default.json
+++ b/files/unit/unit-default.json
@@ -4,7 +4,6 @@
       "pass": "routes"
     }
   },
-
   "routes": [
     {
       "match": {
@@ -13,21 +12,19 @@
           "*.php/*"
         ]
       },
-
       "action": {
         "pass": "applications/phpapp/direct"
       }
     },
     {
       "action": {
-        "share": "/usr/src/app/public",
+        "share": "/usr/src/app/public$uri",
         "fallback": {
           "pass": "applications/phpapp/index"
         }
       }
     }
   ],
-
   "applications": {
     "phpapp": {
       "type": "php",
@@ -40,7 +37,6 @@
         "direct": {
           "root": "/usr/src/app/public/"
         },
-
         "index": {
           "root": "/usr/src/app/public/",
           "script": "index.php"


### PR DESCRIPTION
Spinning up an 8.1-unit image and HTTPing always tries to redirect:

```
curl -v http://127.0.0.1:8000/
*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000
> GET / HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/8.9.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Location: //
< Server: Unit/1.32.1
< Date: Tue, 25 Mar 2025 15:48:40 GMT
< Content-Length: 0
< 
* Connection #0 to host 127.0.0.1 left intact
```

Comparing with release/8.3 (which works), showed a slight diff :-) 