### PR TITLE
Add PHP 8.5 (ZTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         include:
           - platform: linux/arm64
-            runs_on: ARM64
+            runs_on: ubuntu-24.04-arm
           - platform: linux/amd64
             runs_on: 'ubuntu-latest'
        # exclude:
@@ -90,7 +90,7 @@ jobs:
       matrix:
         include:
           - platform: linux/arm64
-            runs_on: ARM64
+            runs_on: ubuntu-24.04-arm
           - platform: linux/amd64
             runs_on: 'ubuntu-latest'
         #exclude:
@@ -153,7 +153,7 @@ jobs:
       matrix:
         include:
           - platform: linux/arm64
-            runs_on: ARM64
+            runs_on: ubuntu-24.04-arm
           - platform: linux/amd64
             runs_on: 'ubuntu-latest'
         #exclude:
@@ -225,7 +225,7 @@ jobs:
       matrix:
         include:
           - platform: linux/arm64
-            runs_on: ARM64
+            runs_on: ubuntu-24.04-arm
           - platform: linux/amd64
             runs_on: 'ubuntu-latest'
         #exclude:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.0 AS alpine-distro
+FROM alpine:3.23 AS alpine-distro
 FROM alpine-distro AS php-zts-builder
 
 RUN apk add --no-cache libc6-compat
@@ -21,22 +21,22 @@ RUN cp /workspace/.abuild/*.rsa.pub /etc/apk/keys/
 USER alpiner
 
 
-RUN git clone -b 3.21-stable --single-branch --depth=1 https://gitlab.alpinelinux.org/alpine/aports
+RUN git clone -b 3.23-stable --single-branch --depth=1 https://gitlab.alpinelinux.org/alpine/aports
 
-WORKDIR /workspace/aports/community/php84
-RUN cp -rf /workspace/aports/community/php84 /workspace/aports/community/phpzts84
-WORKDIR /workspace/aports/community/phpzts84
-RUN sed -i -e 's/pkgname=php84/pkgname=phpzts84/' APKBUILD
+WORKDIR /workspace/aports/community/php85
+RUN cp -rf /workspace/aports/community/php85 /workspace/aports/community/phpzts85
+WORKDIR /workspace/aports/community/phpzts85
+RUN sed -i -e 's/pkgname=php85/pkgname=phpzts85/' APKBUILD
 # hadolint ignore=SC2016
-RUN sed -i -e 's/\$pkgname-fpm.initd/php84-fpm.initd/' APKBUILD
+RUN sed -i -e 's/\$pkgname-fpm.initd/php85-fpm.initd/' APKBUILD
 # hadolint ignore=SC2016
-RUN sed -i -e 's/\$pkgname-fpm.logrotate/php84-fpm.logrotate/' APKBUILD
+RUN sed -i -e 's/\$pkgname-fpm.logrotate/php85-fpm.logrotate/' APKBUILD
 # hadolint ignore=SC2016
-RUN sed -i -e 's/\$pkgname-module.conf/php84-module.conf/' APKBUILD
+RUN sed -i -e 's/\$pkgname-module.conf/php85-module.conf/' APKBUILD
 # hadolint ignore=SC2016
-RUN sed -i -e 's/\$pkgname-fpm-version-suffix.patch/php84-fpm-version-suffix.patch/' APKBUILD
+RUN sed -i -e 's/\$pkgname-fpm-version-suffix.patch/php85-fpm-version-suffix.patch/' APKBUILD
 # hadolint ignore=SC2016
-RUN sed -i -e 's/php\$_suffix-module.conf/php84-module.conf/' APKBUILD
+RUN sed -i -e 's/php\$_suffix-module.conf/php85-module.conf/' APKBUILD
 RUN sed -i -e 's/--host/--enable-zts --enable-zend-max-execution-timers --enable-zend-timer --disable-zend-signals --host/' APKBUILD
 RUN sed -i -e 's/--with-openssl-argon2//' APKBUILD
 #RUN sed -i -e 's/--with-password-argon2//' APKBUILD
@@ -65,12 +65,12 @@ RUN uname -m
 RUN abuild -A
 RUN abuild checksum && abuild -r
 WORKDIR /workspace/aports/community/unit
-# make phpver3 to be phpzts84
-RUN sed -i -e 's/_phpver4=84/_phpver4=zts84/' APKBUILD
+# make phpver3 to be phpzts85
+RUN sed -i -e 's/_phpver4=85/_phpver4=zts85/' APKBUILD
 RUN sed -i -e 's/.\/configure php --module=php\$_phpver2 --config=php-config\$_phpver2//' APKBUILD
 RUN sed -i -e 's/.\/configure php --module=php\$_phpver3 --config=php-config\$_phpver3//' APKBUILD
 RUN sed -i -e 's/perl php\$_phpver2 php\$_phpver3 php\$_phpver4/perl php\$_phpver4 /' APKBUILD
-# make unit-php84 find the lphpzts84.so
+# make unit-php85 find the lphpzts85.so
 # hadolint ignore=SC2016
 #RUN sed -i -e 's/.\/configure php --module=php\$_phpver4/sed -i -e "s\/lphp\/lphpzts\/g" auto\/modules\/php \&\& cat auto\/modules\/php \&\& .\/configure php --module=php\$_phpver4/g' APKBUILD
 RUN sed -i -e 's/_allow_fail=no/_allow_fail=yes/g' APKBUILD
@@ -79,10 +79,10 @@ RUN abuild checksum && abuild -r
 
 FROM alpine-distro AS php-zts-base
 
-ARG PHP_VERSION="8.4.4"
-ARG PHP_PACKAGE_BASENAME="phpzts84"
-ARG PHP_PACKAGE_INCLUDE="/usr/include/php84"
-ARG PHP_FPM_BINARY_PATH="/usr/sbin/php-fpmzts84"
+ARG PHP_VERSION="8.5.1"
+ARG PHP_PACKAGE_BASENAME="phpzts85"
+ARG PHP_PACKAGE_INCLUDE="/usr/include/php85"
+ARG PHP_FPM_BINARY_PATH="/usr/sbin/php-fpmzts85"
 ENV PHP_VERSION=$PHP_VERSION
 ENV PHP_PACKAGE_BASENAME=$PHP_PACKAGE_BASENAME
 ENV PHP_PACKAGE_INCLUDE=$PHP_PACKAGE_INCLUDE
@@ -153,18 +153,18 @@ RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-tokenizer
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-session
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-sockets
 
-# FIXME: we need this, since phpzts84 is not the _default_php in https://git.alpinelinux.org/aports/tree/community/php84/APKBUILD
+# FIXME: we need this, since phpzts85 is not the _default_php in https://git.alpinelinux.org/aports/tree/community/php85/APKBUILD
 WORKDIR /usr/bin
-RUN    ln -s phpzts84 php \
-    && ln -s peardevzts84 peardev \
-    && ln -s peclzts84 pecl \
-    && ln -s phpizezts84 phpize \
-    && ln -s php-configzts84 php-config \
-    && ln -s phpdbgzts84 phpdbg \
-    && ln -s lsphpzts84 lsphp \
-    && ln -s php-cgizts84 php-cgi \
-    && ln -s phar.pharzts84 phar.phar \
-    && ln -s pharzts84 phar
+RUN    ln -s phpzts85 php \
+    && ln -s peardevzts85 peardev \
+    && ln -s peclzts85 pecl \
+    && ln -s phpizezts85 phpize \
+    && ln -s php-configzts85 php-config \
+    && ln -s phpdbgzts85 phpdbg \
+    && ln -s lsphpzts85 lsphp \
+    && ln -s php-cgizts85 php-cgi \
+    && ln -s phar.pharzts85 phar.phar \
+    && ln -s pharzts85 phar
 
 FROM php-zts-base AS PECL-BUILDER-AMQP
 
@@ -418,8 +418,8 @@ RUN chown www-data:www-data /run/unit/
 RUN apk add --no-cache apache2 ${PHP_PACKAGE_BASENAME}-apache2~=${PHP_VERSION}
 # add default apache2 config file
 COPY files/apache2/apache2-default.conf /etc/apache2/conf.d/00_apache2-default.conf
-# fix that the mod_php84.so is not properly renamed in the conf
-RUN sed -i -e 's/mod_php84/mod_phpzts84/g' /etc/apache2/conf.d/php84-module.conf
+# fix that the mod_php85.so is not properly renamed in the conf
+RUN sed -i -e 's/mod_php85/mod_phpzts85/g' /etc/apache2/conf.d/php85-module.conf
 # activate rewrite module
 RUN sed -i -e 's/#LoadModule rewrite_module/LoadModule rewrite_module/g' /etc/apache2/httpd.conf
 # listen port 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-intl
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-ldap
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-mbstring
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-mysqli
-RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-opcache
+# NOTE: opcache is now built into phpzts85 core, no separate package needed
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-openssl
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pcntl
 RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pdo_mysql
@@ -170,7 +170,7 @@ FROM php-zts-base AS PECL-BUILDER-AMQP
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-amqp
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers rabbitmq-c-dev ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install amqp \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install amqp \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/amqp.so \
     && echo "extension=amqp" > /etc/$PHP_PACKAGE_BASENAME/conf.d/40_amqp.ini \
     && apk del --no-network .build-deps \
@@ -180,7 +180,7 @@ FROM php-zts-base AS PECL-BUILDER-APCU
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-apcu
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install apcu \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install apcu \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/apcu.so \
     && echo "extension=apcu" > /etc/$PHP_PACKAGE_BASENAME/conf.d/apcu.ini \
     && apk del --no-network .build-deps
@@ -189,7 +189,7 @@ FROM php-zts-base AS PECL-BUILDER-IGBINARY
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-igbinary
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install igbinary \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install igbinary \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/igbinary.so \
     && echo "extension=igbinary" > /etc/$PHP_PACKAGE_BASENAME/conf.d/10_igbinary.ini \
     && apk del --no-network .build-deps
@@ -202,7 +202,7 @@ RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automa
     && wget --quiet --no-verbose https://github.com/Imagick/imagick/archive/refs/heads/3.7.0.tar.gz -O /tmp/imagick.tar.gz \
     && tar --strip-components=1 -xf /tmp/imagick.tar.gz \
     && sed -i -e 's/php_strtolower/zend_str_tolower/' imagick.c \
-    && phpizezts84 \
+    && phpizezts85 \
     && ./configure \
     && MAKEFLAGS="-j $(nproc)" make \
     && MAKEFLAGS="-j $(nproc)" make install \
@@ -216,7 +216,7 @@ FROM php-zts-base AS PECL-BUILDER-MSGPACK
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-msgpack
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install msgpack \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install msgpack \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/msgpack.so \
     && echo "extension=msgpack" > /etc/$PHP_PACKAGE_BASENAME/conf.d/10_msgpack.ini \
     && apk del --no-network .build-deps
@@ -231,7 +231,7 @@ COPY --from=PECL-BUILDER-MSGPACK /etc/$PHP_PACKAGE_BASENAME/conf.d/10_msgpack.in
 COPY --from=PECL-BUILDER-MSGPACK $PHP_PACKAGE_INCLUDE/ext/msgpack $PHP_PACKAGE_INCLUDE/ext/msgpack
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-memcached
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers zlib-dev libmemcached-dev cyrus-sasl-dev libevent-dev ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install -D 'enable-memcached-igbinary="yes" enable-memcached-session="yes" enable-memcached-json="yes" enable-memcached-protocol="yes" enable-memcached-msgpack="yes"' memcached \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install -D 'enable-memcached-igbinary="yes" enable-memcached-session="yes" enable-memcached-json="yes" enable-memcached-protocol="yes" enable-memcached-msgpack="yes"' memcached \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/memcached.so \
     && echo "extension=memcached" > /etc/$PHP_PACKAGE_BASENAME/conf.d/20_memcached.ini \
     && apk del --no-network .build-deps \
@@ -241,7 +241,7 @@ FROM php-zts-base AS PECL-BUILDER-PROTOBUF
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-protobuf
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install protobuf \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install protobuf \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/protobuf.so \
     && echo "extension=protobuf" > /etc/$PHP_PACKAGE_BASENAME/conf.d/protobuf.ini \
     && apk del --no-network .build-deps
@@ -253,7 +253,7 @@ COPY --from=PECL-BUILDER-IGBINARY /etc/$PHP_PACKAGE_BASENAME/conf.d/10_igbinary.
 COPY --from=PECL-BUILDER-IGBINARY $PHP_PACKAGE_INCLUDE/ext/igbinary $PHP_PACKAGE_INCLUDE/ext/igbinary
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-redis
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers lz4-dev zstd-dev ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install -D 'enable-redis-igbinary="yes" enable-redis-lz4="yes" with-liblz4="yes" enable-redis-lzf="yes" enable-redis-zstd="yes"' redis \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install -D 'enable-redis-igbinary="yes" enable-redis-lz4="yes" with-liblz4="yes" enable-redis-lzf="yes" enable-redis-zstd="yes"' redis \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/redis.so \
     && echo "extension=redis" > /etc/$PHP_PACKAGE_BASENAME/conf.d/20_redis.ini \
     && apk del --no-network .build-deps
@@ -262,7 +262,7 @@ FROM php-zts-base AS PECL-BUILDER-XDEBUG
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-xdebug
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install xdebug \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install xdebug \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/xdebug.so \
     && echo ";zend_extension=xdebug.so" > /etc/$PHP_PACKAGE_BASENAME/conf.d/50_xdebug.ini \
     && echo ";xdebug.mode=off" >> /etc/$PHP_PACKAGE_BASENAME/conf.d/50_xdebug.ini \
@@ -273,7 +273,7 @@ FROM php-zts-base AS PECL-BUILDER-GRPC
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-grpc~=$GRPC_EXTENSION_VERSION --repository $GRPC_EXTENSION_REPOSITORY
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install grpc \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install grpc \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/grpc.so \
     && echo "extension=grpc" > /etc/$PHP_PACKAGE_BASENAME/conf.d/grpc.ini \
     && apk del --no-network .build-deps
@@ -282,7 +282,7 @@ FROM php-zts-base AS PECL-BUILDER-PCOV
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-pcov~=$PCOV_EXTENSION_VERSION --repository $PCOV_EXTENSION_REPOSITORY
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts84 install pcov \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install pcov \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/pcov.so \
     && echo "extension=pcov" > /etc/$PHP_PACKAGE_BASENAME/conf.d/pcov.ini \
     && apk del --no-network .build-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,12 +64,10 @@ RUN arch
 RUN uname -m
 RUN abuild -A
 RUN abuild checksum && abuild -r
-WORKDIR /workspace/aports/community/unit
-# make phpver3 to be phpzts85
-RUN sed -i -e 's/_phpver4=85/_phpver4=zts85/' APKBUILD
-RUN sed -i -e 's/.\/configure php --module=php\$_phpver2 --config=php-config\$_phpver2//' APKBUILD
-RUN sed -i -e 's/.\/configure php --module=php\$_phpver3 --config=php-config\$_phpver3//' APKBUILD
-RUN sed -i -e 's/perl php\$_phpver2 php\$_phpver3 php\$_phpver4/perl php\$_phpver4 /' APKBUILD
+WORKDIR /workspace/aports/community/unit-php85
+# rename package and change PHP version for ZTS build
+RUN sed -i -e 's/pkgname=unit-php85/pkgname=unit-phpzts85/' APKBUILD
+RUN sed -i -e 's/_phpver=85/_phpver=zts85/' APKBUILD
 # make unit-php85 find the lphpzts85.so
 # hadolint ignore=SC2016
 #RUN sed -i -e 's/.\/configure php --module=php\$_phpver4/sed -i -e "s\/lphp\/lphpzts\/g" auto\/modules\/php \&\& cat auto\/modules\/php \&\& .\/configure php --module=php\$_phpver4/g' APKBUILD
@@ -199,9 +197,8 @@ FROM php-zts-base AS PECL-BUILDER-IMAGICK
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-imagick
 # FIXME: we do this because of https://github.com/Imagick/imagick/issues/689
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers imagemagick imagemagick-dev imagemagick-libs ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && wget --quiet --no-verbose https://github.com/Imagick/imagick/archive/refs/heads/3.7.0.tar.gz -O /tmp/imagick.tar.gz \
+    && wget --quiet --no-verbose https://github.com/Imagick/imagick/archive/refs/tags/3.8.1.tar.gz -O /tmp/imagick.tar.gz \
     && tar --strip-components=1 -xf /tmp/imagick.tar.gz \
-    && sed -i -e 's/php_strtolower/zend_str_tolower/' imagick.c \
     && phpizezts85 \
     && ./configure \
     && MAKEFLAGS="-j $(nproc)" make \
@@ -273,7 +270,7 @@ FROM php-zts-base AS PECL-BUILDER-GRPC
 
 # FIXME: RUN apk add --no-cache ${PHP_PACKAGE_BASENAME}-pecl-grpc~=$GRPC_EXTENSION_VERSION --repository $GRPC_EXTENSION_REPOSITORY
 RUN apk add --no-cache binutils build-base openssl-dev autoconf pcre2-dev automake libtool linux-headers ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
-    && MAKEFLAGS="-j $(nproc)" peclzts85 install grpc \
+    && MAKEFLAGS="-j $(nproc)" peclzts85 install grpc-1.78.0RC2 \
     && strip --strip-all /usr/lib/$PHP_PACKAGE_BASENAME/modules/grpc.so \
     && echo "extension=grpc" > /etc/$PHP_PACKAGE_BASENAME/conf.d/grpc.ini \
     && apk del --no-network .build-deps
@@ -302,13 +299,13 @@ RUN apk add --no-cache binutils build-base libstdc++ cmake automake libtool linu
 
 # install caddy with frankenphp
 # hadolint ignore=SC2016,SC2086,DL3003
-RUN apk add --no-cache go~=1.23 --virtual .go-build-deps \
+RUN apk add --no-cache go~=1.25 --virtual .go-build-deps \
     && apk add --no-cache libxml2-dev sqlite-dev argon2-dev brotli-dev build-base openssl-dev ${PHP_PACKAGE_BASENAME}-dev~=${PHP_VERSION} --virtual .build-deps \
     && cd /opt \
     && find / | grep php | grep .so \
-    && git clone https://github.com/dunglas/frankenphp.git --recursive  --branch v1.4.0 --single-branch \
+    && git clone https://github.com/php/frankenphp.git --recursive  --branch v1.11.1 --single-branch \
     && cd /opt/frankenphp/caddy/frankenphp \
-    && export PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 `php-config --includes`" \
+    && export PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wno-error=attributes `php-config --includes`" \
     && export PHP_CPPFLAGS="$PHP_CFLAGS" \
     && export PHP_LDFLAGS="-Wl,-O1 -pie `php-config --ldflags` `php-config --libs` -Wl,-rpath,/usr/lib/${PHP_PACKAGE_BASENAME} -L/usr/lib/${PHP_PACKAGE_BASENAME}" \
     && export CGO_LDFLAGS="$PHP_LDFLAGS" CGO_CFLAGS=$PHP_CFLAGS CGO_CPPFLAGS=$PHP_CPPFLAGS \

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ The `-apache2` tagged docker image (because it has attached this snippet at [fil
 
 ## fpm
 
-The `/etc/php82/php-fpm.d/www.conf` is adjusted:
+The `/etc/php85/php-fpm.d/www.conf` is adjusted:
 
 * `user` + `group` is set to `www-data` to ensure it's running www-data as user/group
 * `listen` is set to `0.0.0.0:9000` to be accessible by other docker hosts
@@ -250,7 +250,7 @@ The `/etc/php82/php-fpm.d/www.conf` is adjusted:
 * `decorate_workers_output` is set to `no` to remove the decorator like `TIMESTAMP WARNING: [pool www] child 7 said into stderr "` around each message
 * `php_admin_flag[fastcgi.logging]` is set to `off` to avoid that the fastcgi consumer (e.g. nginx) duplicates the fpm messages and prefixes it like this `FastCGI sent in stderr`
 
-The `/etc/php82/php-fpm.conf` is adjusted:
+The `/etc/php85/php-fpm.conf` is adjusted:
 
 * `error_log` is set to `/dev/stderr` to log error to the stderr
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# endava/docker-php:8.4.x-zts
+# endava/docker-php:8.5.x-zts
 
 ## Usage
 
@@ -12,7 +12,7 @@ $ echo '<?php phpinfo();' > public/index.php
 ### Run the NGINX Unit Version
 
 ```shell
-$ docker run --rm -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it  endava/php:8.4.2-zts-unit
+$ docker run --rm -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it  endava/php:8.5.1-zts-unit
 ```
 
 and open http://localhost:8080 to see phpinfo unit.
@@ -26,7 +26,7 @@ Time per request:       23.207 [ms] (mean)
 ### Run the Apache2 Version
 
 ```shell
-$ docker run --rm -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it  endava/php:8.4.2-zts-apache2
+$ docker run --rm -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it  endava/php:8.5.1-zts-apache2
 ```
 
 and open http://localhost:8080 to see phpinfo on apache2.
@@ -48,7 +48,7 @@ version: "2.1"
 
 services:
   php-cli:
-    image: endava/php:8.4.2-zts
+    image: endava/php:8.5.1-zts
     volumes:
       - ./:/usr/src/app
     user: "${UID-www-data}:${GID-www-data}"
@@ -56,7 +56,7 @@ services:
     depends_on:
       - nginx
   php-fpm:
-    image: endava/php:8.4.2-zts-fpm
+    image: endava/php:8.5.1-zts-fpm
     user: "${UID-www-data}:${GID-www-data}"
     volumes:
       - ./:/usr/src/app
@@ -99,11 +99,11 @@ $docker-compose run php-cli
 ⠿ Container docker-php-php-fpm-1
 ⠿ Container docker-php-nginx-1
 bash-5.1$ php -v
-PHP 8.4.2 (cli) (built: Jan 15 2025 22:38:51) (ZTS)
+PHP 8.5.1 (cli) (built: Jan 9 2026 22:38:51) (ZTS)
 Copyright (c) The PHP Group
-Zend Engine v4.4.2, Copyright (c) Zend Technologies
-    with Zend OPcache v8.4.2, Copyright (c), by Zend Technologies
-    with Xdebug v3.4.1, Copyright (c) 2002-2025, by Derick Rethans
+Zend Engine v4.5.1, Copyright (c) Zend Technologies
+    with Zend OPcache v8.5.1, Copyright (c), by Zend Technologies
+    with Xdebug v3.5.0, Copyright (c) 2002-2026, by Derick Rethans
 ```
 
 and open http://localhost:8080/ to see phpinfo with FPM/FastCGI as server api.
@@ -111,7 +111,7 @@ and open http://localhost:8080/ to see phpinfo with FPM/FastCGI as server api.
 ### Run the frankenphp https Version
 
 ```shell
-$ docker run --rm -p 8443:443 -v `pwd`/public:/usr/src/app/public -it  endava/php:8.4.2-zts-frankenphp
+$ docker run --rm -p 8443:443 -v `pwd`/public:/usr/src/app/public -it  endava/php:8.5.1-zts-frankenphp
 ```
 
 and open https://localhost:8443/ to see phpinfo with frankenphp as server api.
@@ -127,7 +127,7 @@ Time per request:       21.920 [ms] (mean)
 ### Run the frankenphp http Version
 
 ```shell
-$ docker run --rm -e SERVER_NAME=http://:8080 -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it endava/php:8.4.2-zts-frankenphp
+$ docker run --rm -e SERVER_NAME=http://:8080 -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it endava/php:8.5.1-zts-frankenphp
 ```
 
 and open https://localhost:8443/ to see phpinfo with frankenphp as server api.
@@ -143,7 +143,7 @@ Time per request:       21.920 [ms] (mean)
 ### Run the frankenphp http worker Version
 
 ```shell
-$ docker run --rm  -e FRANKENPHP_CONFIG="worker ./public/index.php" -e SERVER_NAME=http://:8080 -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it endava/php:8.4.2-zts-frankenphp
+$ docker run --rm  -e FRANKENPHP_CONFIG="worker ./public/index.php" -e SERVER_NAME=http://:8080 -p 8080:8080 -v `pwd`/public:/usr/src/app/public -it endava/php:8.5.1-zts-frankenphp
 ```
 
 and index.php like this:
@@ -317,7 +317,7 @@ You can define the crontab's content with an environment variable like this:
 ```yaml
 services:
   import-data-cron:
-    image: endava/php:8.4.2-zts
+    image: endava/php:8.5.1-zts
     command: start-cron
     environment:
       - 'CRONTAB_USER=www-data'
@@ -361,7 +361,7 @@ Usage in your `docker-compose.yml`:
 ```yaml
 services:
   crontab:
-    image: endava/php:8.4.2-zts
+    image: endava/php:8.5.1-zts
     command: start-cron
     volumes:
       - ./:/usr/src/app
@@ -374,7 +374,7 @@ cron location with the `CRON_PATH` environment variable:
 ```yaml
 services:
   crontab:
-    image: endava/php:8.4.2-zts
+    image: endava/php:8.5.1-zts
     command: start-cron
     environment:
       - CRON_PATH=/usr/src/app/crontabs


### PR DESCRIPTION
  - Removed the opcache package installation (now built into PHP 8.5 core)
  - Updated all peclzts84 references to peclzts85 
  - Updated phpizezts84 to phpizezts85
  - refs/heads/3.7.0.tar.gz to refs/tags/3.8.1.tar.gz (3.8.1 includes PHP 8.5 support php_smart_string.h fix) 
  - Removed sed 's/php_strtolower/zend_str_tolower/' (Already fixed in 3.8.1 ) 
  - go~=1.23 to go~=1.25 (Alpine 3.23 ships Go 1.25, not 1.23)
  - dunglas/frankenphp to php/frankenphp (Repo moved to official PHP organization) 
  - v1.4.0 to v1.11.1 (v1.10.0+ has PHP 8.5 support)
  - Added -Wno-error=attributes to CFLAGS (Suppress GCC warning for preserve_none attribute (PHP 8.5 uses new calling convention))
  - install grpc to install grpc-1.78.0RC2 (1.78.0RC2 includes PHP 8.5 support) 
  - Added sed 's/pkgname=unit-php85/pkgname=unit-phpzts85/' (Rename package so final stage can find unit-phpzts85)